### PR TITLE
Potential fix for code scanning alert no. 16: Missing CSRF middleware

### DIFF
--- a/src/middlewares/app.ts
+++ b/src/middlewares/app.ts
@@ -6,7 +6,7 @@ import morgan from 'morgan';
 import fs from 'fs';
 import path from 'path';
 import cookieParser from 'cookie-parser';
-// import lusca from 'lusca';
+import lusca from 'lusca';
 import { createBullBoard } from '@bull-board/api';
 import { BullAdapter } from '@bull-board/api/bullAdapter';
 import { ExpressAdapter } from '@bull-board/express';
@@ -69,7 +69,7 @@ export const configureMiddlewares = (app: Application): void => {
   );
 
   app.use(cookieParser());
-  // app.use(lusca.csrf());
+  app.use(lusca.csrf());
 
   app.use(express.json({ limit: '10kb' }));
   app.use(express.urlencoded({ extended: true, limit: '10kb' }));


### PR DESCRIPTION
Potential fix for [https://github.com/iamkabelomoobi/work-whiz/security/code-scanning/16](https://github.com/iamkabelomoobi/work-whiz/security/code-scanning/16)

To fix the issue, we will add CSRF protection middleware to the application. The `lusca` library is a well-known middleware for CSRF protection in Express applications. We will:
1. Uncomment the `lusca` import on line 9.
2. Add the `lusca.csrf()` middleware to the application, ensuring it is applied after `cookieParser()` and before any routes that handle sensitive operations.
3. Ensure that the CSRF token is included in the responses where necessary (e.g., in forms or headers) so that clients can include it in subsequent requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Uncommented and enabled CSRF protection middleware using lusca to address code scanning security alert